### PR TITLE
fix(lifecycle): harden plugin startup and shutdown lifecycle

### DIFF
--- a/src/main/java/me/glaremasters/guilds/Guilds.java
+++ b/src/main/java/me/glaremasters/guilds/Guilds.java
@@ -110,21 +110,39 @@ public final class Guilds extends JavaPlugin {
     public void onDisable() {
         if (checkVault() && economy != null) {
             try {
-                guildHandler.saveData();
-                cooldownHandler.saveCooldowns();
-                arenaHandler.saveArenas();
+                if (guildHandler != null) {
+                    guildHandler.saveData();
+                }
+                if (cooldownHandler != null) {
+                    cooldownHandler.saveCooldowns();
+                }
+                if (arenaHandler != null) {
+                    arenaHandler.saveArenas();
+                }
             } catch (IOException e) {
                 e.printStackTrace();
             }
             guildHandler.chatLogout();
             guildHandler.getLookupCache().clear();
             commandManager.unregisterCommands();
+            if (guildHandler != null) {
+                guildHandler.chatLogout();
+                guildHandler.getLookupCache().clear();
+            }
+            if (commandManager != null) {
+                commandManager.unregisterCommands();
+            }
         }
 
         if (database != null) {
             LoggingUtils.info("Shutting down database...");
             database.close();
             LoggingUtils.info("Database has been shut down.");
+        }
+
+        if (adventure != null) {
+            adventure.close();
+            adventure = null;
         }
     }
 
@@ -164,6 +182,12 @@ public final class Guilds extends JavaPlugin {
 
         if (economy == null) {
             LoggingUtils.warn("It looks like you don't have an Economy plugin on your server! Stopping plugin..");
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        if (permissions == null) {
+            LoggingUtils.warn("It looks like you don't have a Permissions plugin hooked into Vault on your server! Stopping plugin..");
             Bukkit.getPluginManager().disablePlugin(this);
             return;
         }


### PR DESCRIPTION
This pull request improves the robustness of the plugin's lifecycle management by adding additional null checks and resource cleanup to the `onDisable` method, and by ensuring that the plugin will not enable if a required Permissions plugin is missing. These changes help prevent errors during shutdown and startup, and improve the stability of the plugin.

Lifecycle management improvements:

* Added null checks for `guildHandler`, `cooldownHandler`, `arenaHandler`, and `commandManager` before calling their respective shutdown and cleanup methods in `onDisable` to prevent potential `NullPointerException`s. Also added cleanup for the `adventure` resource.

Startup validation:

* Added a check in `onEnable` to ensure a Permissions plugin is hooked into Vault; if not, the plugin logs a warning and disables itself to prevent running in an invalid state.