### PR TITLE
chore(ci): run gradle checks in workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Java
         uses: actions/setup-java@v5
@@ -41,5 +41,8 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew
 
+      - name: Run Gradle checks
+        run: ./gradlew clean check --no-daemon --stacktrace --no-configuration-cache
+
       - name: Build shaded plugin
-        run: ./gradlew clean shadowJar --no-daemon --stacktrace
+        run: ./gradlew shadowJar --no-daemon --stacktrace --no-configuration-cache


### PR DESCRIPTION
This pull request updates the Gradle workflow to improve build reliability and ensure code quality checks are run during CI. The most important changes are:

**CI workflow updates:**

* Updated the `actions/checkout` action to version 7 for improved performance and security.
* Added a new step to run `./gradlew clean check` with additional flags, ensuring all code checks are executed as part of the workflow.
* Modified the build command to remove the redundant `clean` step and added the `--no-configuration-cache` flag to both the check and build steps for more consistent build results.