### PR TITLE
fix: grant guild permissions immediately after creation

### DIFF
--- a/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandCreate.kt
+++ b/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandCreate.kt
@@ -158,13 +158,12 @@ internal class CommandCreate : BaseCommand() {
                 guildHandler.addGuild(guild)
                 economy.withdrawPlayer(player, cost)
                 currentCommandIssuer.sendInfo(Messages.CREATE__SUCCESSFUL, "{guild}", guild.name)
+
+                guildHandler.addToMemberCache(player.uniqueId, guild.id)
                 guildHandler.addGuildPerms(permission, player)
                 guildHandler.addRolePerm(permission, player)
 
                 guild.updateGuildSkull(player, settingsManager)
-
-                guildHandler.addToMemberCache(player.uniqueId, guild.id)
-
 
                 actionHandler.removeAction(player)
             }


### PR DESCRIPTION
## Summary

Ensure a newly created guild member is added to the member cache before Guilds resolves and applies the guild-tier and role permission nodes.

## Root cause

Guild creation called `addGuildPerms` and `addRolePerm` before adding the creator to `memberCache`. Both permission methods look the player's guild up through that cache, so the lookup returned `null` and the initial permission assignment was skipped until the player rejoined.

## Changes

- add the guild creator to `memberCache` immediately after the guild is registered
- apply guild-tier and role permissions only after that cache entry exists
- leave tier-upgrade behavior unchanged

## Validation

- verified the branch contains one commit and modifies only `CommandCreate.kt`
- reviewed the generated diff to confirm this is strictly an ordering change

Fixes #708