### PR TITLE
fix: validate color-code markers against guild regex

### DIFF
--- a/src/main/java/me/glaremasters/guilds/utils/GuildInputValidator.java
+++ b/src/main/java/me/glaremasters/guilds/utils/GuildInputValidator.java
@@ -1,0 +1,108 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Glare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package me.glaremasters.guilds.utils;
+
+import ch.jalu.configme.SettingsManager;
+import me.glaremasters.guilds.configuration.sections.GuildSettings;
+
+import java.util.regex.Pattern;
+
+/**
+ * Validates guild names and prefixes against their configured regular expressions.
+ */
+public final class GuildInputValidator {
+
+    private static final char SECTION_SIGN = '\u00A7';
+    private static final Pattern ALTERNATE_COLOR_CODE = Pattern.compile("(?i)&[0-9A-FK-ORX]");
+    private static final Pattern SECTION_COLOR_CODE = Pattern.compile("(?i)" + SECTION_SIGN + "[0-9A-FK-ORX]");
+    private static final Pattern ANY_COLOR_CODE = Pattern.compile("(?i)(?:&|" + SECTION_SIGN + ")[0-9A-FK-ORX]");
+
+    private GuildInputValidator() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    /**
+     * Validate a guild name using the configured name requirements.
+     *
+     * @param input the raw guild name
+     * @param settingsManager the settings manager
+     * @return true when the input satisfies the configured requirements
+     */
+    public static boolean isValidName(String input, SettingsManager settingsManager) {
+        return matchesRequirements(
+                input,
+                settingsManager.getProperty(GuildSettings.NAME_REQUIREMENTS),
+                settingsManager.getProperty(GuildSettings.INCLUDE_COLOR_CODES)
+        );
+    }
+
+    /**
+     * Validate a guild prefix using the configured prefix requirements.
+     *
+     * @param input the raw guild prefix
+     * @param settingsManager the settings manager
+     * @return true when the input satisfies the configured requirements
+     */
+    public static boolean isValidPrefix(String input, SettingsManager settingsManager) {
+        return matchesRequirements(
+                input,
+                settingsManager.getProperty(GuildSettings.PREFIX_REQUIREMENTS),
+                settingsManager.getProperty(GuildSettings.INCLUDE_COLOR_CODES)
+        );
+    }
+
+    private static boolean matchesRequirements(String input, String regex, boolean includeColorCodes) {
+        if (includeColorCodes) {
+            return input.matches(regex);
+        }
+
+        final String visibleInput = ANY_COLOR_CODE.matcher(input).replaceAll("");
+        if (!visibleInput.matches(regex)) {
+            return false;
+        }
+
+        if (ALTERNATE_COLOR_CODE.matcher(input).find()
+                && !regexAcceptsCharacter(visibleInput, regex, '&')) {
+            return false;
+        }
+
+        return !SECTION_COLOR_CODE.matcher(input).find()
+                || regexAcceptsCharacter(visibleInput, regex, SECTION_SIGN);
+    }
+
+    private static boolean regexAcceptsCharacter(String validInput, String regex, char character) {
+        if (validInput.isEmpty()) {
+            return String.valueOf(character).matches(regex);
+        }
+
+        for (int i = 0; i < validInput.length(); i++) {
+            final String candidate = validInput.substring(0, i) + character + validInput.substring(i + 1);
+            if (candidate.matches(regex)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandCreate.kt
+++ b/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandCreate.kt
@@ -50,6 +50,7 @@ import me.glaremasters.guilds.guild.GuildMember
 import me.glaremasters.guilds.messages.Messages
 import me.glaremasters.guilds.utils.Constants
 import me.glaremasters.guilds.utils.EconomyUtils
+import me.glaremasters.guilds.utils.GuildInputValidator
 import me.glaremasters.guilds.utils.StringUtils
 import net.milkbowl.vault.economy.Economy
 import net.milkbowl.vault.permission.Permission
@@ -89,17 +90,17 @@ internal class CommandCreate : BaseCommand() {
             throw ExpectationNotMet(Messages.ERROR__BLACKLIST)
         }
 
-        if (!guildHandler.nameCheck(name, settingsManager)) {
+        if (!GuildInputValidator.isValidName(name, settingsManager)) {
             throw ExpectationNotMet(Messages.CREATE__REQUIREMENTS)
         }
 
         if (!settingsManager.getProperty(GuildSettings.DISABLE_PREFIX)) {
             if (prefix != null) {
-                if (!guildHandler.prefixCheck(prefix, settingsManager)) {
+                if (!GuildInputValidator.isValidPrefix(prefix, settingsManager)) {
                     throw ExpectationNotMet(Messages.CREATE__PREFIX_TOO_LONG)
                 }
             } else {
-                if (!guildHandler.prefixCheck(name, settingsManager)) {
+                if (!GuildInputValidator.isValidPrefix(name, settingsManager)) {
                     throw ExpectationNotMet(Messages.CREATE__NAME_TOO_LONG)
                 }
             }

--- a/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandPrefix.kt
+++ b/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandPrefix.kt
@@ -40,6 +40,7 @@ import me.glaremasters.guilds.guild.Guild
 import me.glaremasters.guilds.guild.GuildHandler
 import me.glaremasters.guilds.messages.Messages
 import me.glaremasters.guilds.utils.Constants
+import me.glaremasters.guilds.utils.GuildInputValidator
 import me.glaremasters.guilds.utils.StringUtils
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
@@ -62,7 +63,7 @@ internal class CommandPrefix : BaseCommand() {
             throw ExpectationNotMet(Messages.PREFIX__DISABLED)
         }
 
-        if (!guildHandler.prefixCheck(prefix, settingsManager)) {
+        if (!GuildInputValidator.isValidPrefix(prefix, settingsManager)) {
             throw ExpectationNotMet(Messages.CREATE__PREFIX_TOO_LONG)
         }
 

--- a/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandRename.kt
+++ b/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandRename.kt
@@ -43,6 +43,7 @@ import me.glaremasters.guilds.messages.Messages
 import me.glaremasters.guilds.utils.ClaimUtils
 import me.glaremasters.guilds.utils.Constants
 import me.glaremasters.guilds.utils.EconomyUtils
+import me.glaremasters.guilds.utils.GuildInputValidator
 import me.glaremasters.guilds.utils.StringUtils
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
@@ -66,7 +67,7 @@ internal class CommandRename : BaseCommand() {
             throw ExpectationNotMet(Messages.CREATE__GUILD_NAME_TAKEN)
         }
 
-        if (!guildHandler.nameCheck(name, settingsManager)) {
+        if (!GuildInputValidator.isValidName(name, settingsManager)) {
             throw ExpectationNotMet(Messages.CREATE__REQUIREMENTS)
         }
 


### PR DESCRIPTION
## Summary

Fix guild name and prefix validation when `guild.requirements.include-color-codes` is disabled.

The setting continues to control whether valid color-code sequences count toward the configured length, but the raw color-code marker must still be permitted by the configured regex.

## Root cause

The previous validation translated and stripped color codes before applying the regex. As a result, an input such as `&aGuild` became `Guild` before validation, allowing `&` to bypass a regex that intentionally excluded it.

## Changes

- add a shared `GuildInputValidator` for guild names and prefixes
- strip valid color-code sequences only for visible-length validation when configured
- separately verify that alternate (`&`) and section-sign (`§`) color-code markers are accepted by the configured regex
- use the shared validation for guild creation, renaming, and prefix changes
- preserve the existing behavior when color codes are configured to count toward length

## Local validation

Compiled the exact validator implementation locally with lightweight stubs and ran a standalone assertion harness covering:

- plain names
- forbidden and allowed `&` color codes
- color codes counted versus excluded from length
- multiple formatting codes
- literal ampersands
- prefix validation
- section-sign color codes
- invalid visible characters

Fixes #266