### PR TITLE
fix: prevent duplicate visible guild names

### DIFF
--- a/src/main/java/me/glaremasters/guilds/utils/GuildInputValidator.java
+++ b/src/main/java/me/glaremasters/guilds/utils/GuildInputValidator.java
@@ -24,8 +24,11 @@
 package me.glaremasters.guilds.utils;
 
 import ch.jalu.configme.SettingsManager;
+import co.aikar.commands.ACFBukkitUtil;
 import me.glaremasters.guilds.configuration.sections.GuildSettings;
+import me.glaremasters.guilds.guild.Guild;
 
+import java.util.Collection;
 import java.util.regex.Pattern;
 
 /**
@@ -72,6 +75,21 @@ public final class GuildInputValidator {
         );
     }
 
+    /**
+     * Check whether a guild name is already used, ignoring color formatting and case.
+     *
+     * @param input the raw proposed guild name
+     * @param guilds the existing guilds
+     * @return true when an existing guild has the same visible name
+     */
+    public static boolean isNameTaken(String input, Collection<Guild> guilds) {
+        final String normalizedInput = normalizeName(input);
+        return guilds.stream()
+                .map(Guild::getName)
+                .map(GuildInputValidator::normalizeName)
+                .anyMatch(normalizedInput::equalsIgnoreCase);
+    }
+
     private static boolean matchesRequirements(String input, String regex, boolean includeColorCodes) {
         if (includeColorCodes) {
             return input.matches(regex);
@@ -89,6 +107,10 @@ public final class GuildInputValidator {
 
         return !SECTION_COLOR_CODE.matcher(input).find()
                 || regexAcceptsCharacter(visibleInput, regex, SECTION_SIGN);
+    }
+
+    private static String normalizeName(String input) {
+        return ACFBukkitUtil.removeColors(StringUtils.color(input));
     }
 
     private static boolean regexAcceptsCharacter(String validInput, String regex, char character) {

--- a/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandCreate.kt
+++ b/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandCreate.kt
@@ -82,7 +82,7 @@ internal class CommandCreate : BaseCommand() {
 
         val cost = settingsManager.getProperty(CostSettings.CREATION)
 
-        if (guildHandler.checkGuildNames(name)) {
+        if (GuildInputValidator.isNameTaken(name, guildHandler.guilds.values)) {
             throw ExpectationNotMet(Messages.CREATE__GUILD_NAME_TAKEN)
         }
 

--- a/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandRename.kt
+++ b/src/main/kotlin/me/glaremasters/guilds/commands/management/CommandRename.kt
@@ -63,7 +63,7 @@ internal class CommandRename : BaseCommand() {
     @CommandPermission(Constants.BASE_PERM + "rename")
     @Syntax("%name")
     fun rename(player: Player, @Conditions("perm:perm=RENAME") guild: Guild, name: String) {
-        if (guildHandler.checkGuildNames(name)) {
+        if (GuildInputValidator.isNameTaken(name, guildHandler.guilds.values)) {
             throw ExpectationNotMet(Messages.CREATE__GUILD_NAME_TAKEN)
         }
 


### PR DESCRIPTION
## Summary

Prevent guild creation and renaming from accepting a name that differs from an existing guild only by color formatting or letter case.

## Root cause

Guild names are stored after translating alternate color codes, while the duplicate-name check compared the stored formatted string directly against the raw command input. This allowed visually identical names such as `&aKnights` and `&bKnights` to coexist.

## Changes

- add a shared visible-name uniqueness check to `GuildInputValidator`
- translate alternate color codes and remove formatting from both existing and proposed names before comparison
- keep the comparison case-insensitive
- use the normalized check during guild creation and guild rename
- leave name storage and display formatting unchanged

## Local validation

Compiled the exact validator locally with lightweight dependency stubs and ran standalone behavior checks covering:

- different `&` colors on the same visible name
- existing `§`-formatted names
- case-only differences
- formatting-only differences
- genuinely distinct names and suffixes