### PR TITLE
feat: open specific guild vaults by number

### DIFF
--- a/src/main/kotlin/me/glaremasters/guilds/commands/gui/CommandGUI.kt
+++ b/src/main/kotlin/me/glaremasters/guilds/commands/gui/CommandGUI.kt
@@ -29,12 +29,15 @@ import co.aikar.commands.annotation.CommandPermission
 import co.aikar.commands.annotation.Conditions
 import co.aikar.commands.annotation.Dependency
 import co.aikar.commands.annotation.Description
+import co.aikar.commands.annotation.Optional
 import co.aikar.commands.annotation.Subcommand
 import co.aikar.commands.annotation.Syntax
 import dev.triumphteam.gui.guis.PaginatedGui
 import me.glaremasters.guilds.Guilds
+import me.glaremasters.guilds.exceptions.ExpectationNotMet
 import me.glaremasters.guilds.exceptions.InvalidTierException
 import me.glaremasters.guilds.guild.Guild
+import me.glaremasters.guilds.messages.Messages
 import me.glaremasters.guilds.utils.Constants
 import org.bukkit.entity.Player
 
@@ -86,9 +89,16 @@ internal class CommandGUI : BaseCommand() {
 
     @Subcommand("vault")
     @Description("{@@descriptions.vault}")
-    @Syntax("")
+    @Syntax("%optional %vault-number")
     @CommandPermission(Constants.BASE_PERM + "vault")
-    fun vault(player: Player, @Conditions("perm:perm=OPEN_VAULT") guild: Guild) {
-        guilds.guiHandler.vaults.get(guild, player).open(player)
+    fun vault(player: Player, @Conditions("perm:perm=OPEN_VAULT") guild: Guild, @Optional vaultNumber: Int?) {
+        if (vaultNumber == null) {
+            guilds.guiHandler.vaults.get(guild, player).open(player)
+            return
+        }
+
+        if (!guilds.guiHandler.vaults.open(guild, player, vaultNumber)) {
+            throw ExpectationNotMet(Messages.VAULTS__MAXED)
+        }
     }
 }

--- a/src/main/kotlin/me/glaremasters/guilds/guis/VaultGUI.kt
+++ b/src/main/kotlin/me/glaremasters/guilds/guis/VaultGUI.kt
@@ -51,27 +51,50 @@ class VaultGUI(private val guilds: Guilds, private val settingsManager: Settings
         addItems(gui, guild, player)
         addBackground(gui)
 
-        num = 0
         return gui
+    }
+
+    /**
+     * Opens a specific guild vault, creating any missing cached vaults up to that number.
+     *
+     * @param guild the guild that owns the vault
+     * @param player the player opening the vault
+     * @param vaultNumber the one-based vault number
+     * @return true when the vault was valid and opened, otherwise false
+     */
+    fun open(guild: Guild, player: Player, vaultNumber: Int): Boolean {
+        if (vaultNumber < 1 || !guildHandler.hasVaultUnlocked(vaultNumber, guild)) {
+            return false
+        }
+
+        val vaults = guildHandler.vaults[guild] ?: return false
+        while (vaults.size < vaultNumber) {
+            vaults.add(guildHandler.createNewVault(settingsManager))
+        }
+
+        player.openInventory(guildHandler.getGuildVault(guild, vaultNumber))
+        guildHandler.opened.add(player)
+        return true
     }
 
     /**
      * Create the regular items that will be on the GUI
      *
-     * @param pane the pane to be added to
+     * @param gui the GUI to add items to
      * @param guild the guild of the player
      */
     private fun addItems(gui: Gui, guild: Guild, player: Player) {
         val max = guildHandler.getGuildTier(guild.tier.level)?.vaultAmount!!
         for (i in 0 until max) {
-            val status = if (guildHandler.hasVaultUnlocked(i + 1, guild)) settingsManager.getProperty(VaultPickerSettings.PICKER_UNLOCKED) else settingsManager.getProperty(VaultPickerSettings.PICKER_LOCKED)
+            val vaultNumber = i + 1
+            val status = if (guildHandler.hasVaultUnlocked(vaultNumber, guild)) settingsManager.getProperty(VaultPickerSettings.PICKER_UNLOCKED) else settingsManager.getProperty(VaultPickerSettings.PICKER_LOCKED)
 
             val lore = settingsManager.getProperty(VaultPickerSettings.PICKER_LORE)
             val updated = mutableListOf<String>()
 
             lore.forEach { line ->
                 updated.add(StringUtils.color(line
-                        .replace("{number}", (num + 1).toString())
+                        .replace("{number}", vaultNumber.toString())
                         .replace("{status}", status)
                 ))
             }
@@ -80,21 +103,10 @@ class VaultGUI(private val guilds: Guilds, private val settingsManager: Settings
 
             item.setAction { event ->
                 event.isCancelled = true
-                try {
-                    guildHandler.getGuildVault(guild, event.rawSlot + 1)
-                } catch (ex: IndexOutOfBoundsException) {
-                    guildHandler.vaults[guild]?.add(guildHandler.createNewVault(settingsManager))
-                }
-                player.openInventory(guildHandler.getGuildVault(guild, event.rawSlot + 1))
-                guildHandler.opened.add(player)
+                open(guild, player, vaultNumber)
             }
 
             gui.addItem(item)
-            num++
         }
-    }
-
-    companion object {
-        private var num = 0
     }
 }


### PR DESCRIPTION
## Summary

Add direct access to numbered guild vaults while preserving the existing vault picker behavior.

Players can now use:

- `/guild vault` to open the existing picker GUI
- `/guild vault <number>` to open a specific unlocked vault directly

## Changes

- add an optional vault number argument to the existing vault command
- extract vault opening into a shared `VaultGUI.open` path used by both the command and picker
- validate one-based vault numbers against the guild tier
- create every missing cached vault up to the requested number before opening it
- use the loop index for picker numbering and click handling
- remove the shared companion-object counter from `VaultGUI`

## Why

The previous picker kept a static counter shared by every GUI instance and only created one missing vault per click. Opening a higher-numbered vault with an incomplete cache could still result in an out-of-bounds lookup.

## Local validation

Ran standalone Kotlin behavior checks covering:

- direct access to an unlocked vault
- filling all missing vaults up to the requested number
- opening the correct requested inventory
- rejecting vault zero
- rejecting vaults above the guild tier limit
- avoiding cache mutation for invalid requests

Fixes #323